### PR TITLE
GitHub Actions auf v4 aktualisiert (Node.js 20 Deprecation)

### DIFF
--- a/.github/workflows/publish-page-ci.yml
+++ b/.github/workflows/publish-page-ci.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # update the Node version to meet your needs
           node-version: 18


### PR DESCRIPTION
fix gh-actions