### PR TITLE
CI: actions/checkout und setup-node auf v5 (Node.js 24) aktualisiert

### DIFF
--- a/.github/workflows/publish-page-ci.yml
+++ b/.github/workflows/publish-page-ci.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 18
           cache: npm


### PR DESCRIPTION
update to v5